### PR TITLE
Horizontal overflow on Landing page

### DIFF
--- a/landing/src/styles/landing.module.css
+++ b/landing/src/styles/landing.module.css
@@ -113,6 +113,7 @@
   box-sizing: border-box;
   text-align: center;
   border-radius: 7px;
+  overflow-x: hidden;
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
 }
 

--- a/landing/src/styles/landing.module.css
+++ b/landing/src/styles/landing.module.css
@@ -69,7 +69,6 @@
 }
 
 .p1 {
-  width: 100vw;
   height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
There is an issue open for this: [#17](https://github.com/bundit/kord-app/issues/17)

![image](https://user-images.githubusercontent.com/15005470/103507334-972f7580-4e67-11eb-948d-b5530157d508.png)

I would like to throw in a possible solution 😅 
I got the landing page running locally and removing the `width: 100vw;` does not break the style of the site.
I generally do not like setting `overflow-x: hidden`, however in this situation it might be a good idea to use it on the landing page as some items fly in from the side, but an easy/quick fix for now is this until myself or someone else looks deeper into a better solution 😅
