### PR TITLE
Fix: Unable to parse Spotify profiles w/ no profile image.

### DIFF
--- a/client/src/components/layout/header.js
+++ b/client/src/components/layout/header.js
@@ -1,10 +1,12 @@
-import { faAngleLeft, faAngleRight } from "@fortawesome/free-solid-svg-icons";
+import {
+  faAngleLeft,
+  faAngleRight,
+  faUser
+} from "@fortawesome/free-solid-svg-icons";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUser } from "@fortawesome/free-solid-svg-icons";
 
 import {
   IconButton as BackwardButton,
@@ -17,6 +19,7 @@ import { dequeRoute, openSettings } from "../../redux/actions/userActions";
 import { getTitleFromPathname } from "../../utils/formattingHelpers";
 import Image from "../image";
 import SearchBar from "../search-bar";
+import avatarImg from "../../assets/avatar-placeholder.png";
 import styles from "../../styles/header.module.scss";
 
 function Header({ location }) {
@@ -97,7 +100,7 @@ function Header({ location }) {
               onClick={toggleSettingsMenu}
             >
               <Image
-                src={mainUser.image}
+                src={mainUser.image || avatarImg}
                 alt="profilePic"
                 style={{
                   width: "inherit",

--- a/client/src/redux/actions/spotifyActions.js
+++ b/client/src/redux/actions/spotifyActions.js
@@ -403,7 +403,7 @@ function mapSpotifyArtist(json) {
 function mapJsonToProfile(json) {
   return {
     username: json.display_name,
-    image: json.images[0].url,
+    image: json.images[0] ? json.images[0].url : undefined,
     profileUrl: json.external_urls.spotify,
     id: json.id,
     isConnected: true


### PR DESCRIPTION
Also: Add default profile image to main view

Addresses #18 and #30